### PR TITLE
Warn users if bower/npm dependencies are missing (resolves #28)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
   "globals": {
     "define": true,
     "module": true,
-    "require": true
+    "require": true,
+    "process": true
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,8 @@ module.exports = exports = function(grunt) {
         'Gruntfile.js',
         'recroom.js',
         'src/*.js',
-        'test/**/test.*.js'
+        'test/**/test.*.js',
+        'utils.js'
     ];
 
     grunt.initConfig({

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "shelljs": "~0.2.6",
     "chalk": "~0.4.0",
     "nopt": "~2.2.0",
+    "extfs": "~0.0.7",
     "grunt": "~0.4.4",
     "load-grunt-tasks": "^0.4.0",
     "grunt-shell": "^0.6.4",

--- a/recroom.js
+++ b/recroom.js
@@ -9,6 +9,8 @@ var nopt = require('nopt');
 var shell = require('shelljs');
 var spawn = require('child_process').spawn;
 
+var util = require('./utils');
+
 var binaryPath = __dirname + '/node_modules/.bin/';
 
 var opts = nopt({
@@ -131,17 +133,28 @@ if (command === 'new' || command === 'create') {
                                                        // (build, serve, test).
     // Pipe out to grunt watch:build -- this is the first step to running your
     // packaged app inside Desktop B2G.
-    if (opts.app) {
-        spawn(binaryPath + 'grunt', ['build'], {
-            stdio: 'inherit'
-        });
-        spawn(binaryPath + 'grunt', ['watch:build'], {
-            stdio: 'inherit'
-        });
-    } else {
-        spawn(binaryPath + 'grunt', ['serve'], {
-            stdio: 'inherit'
-        });
+    var dependenciesExist = util.checkForDeps(["app/bower_components", "node_modules"]);
+
+    if (dependenciesExist === true) {
+         if (opts.app) {
+            spawn(binaryPath + 'grunt', ['build'], {
+                stdio: 'inherit'
+            });
+            spawn(binaryPath + 'grunt', ['watch:build'], {
+                stdio: 'inherit'
+            });
+        } else {
+            spawn(binaryPath + 'grunt', ['serve'], {
+                stdio: 'inherit'
+            });
+        }   
+    }
+    else {
+        console.log(
+            chalk.red('Warning: Some project dependencies are missing. Aborting...') + 
+            chalk.yellow('\nTry running `bower install && npm install` from the root of your project.')
+        );
+        shell.exit(1);
     }
 } else if (command === 'test') {
     spawn(binaryPath + 'grunt', ['test'], {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,37 @@
+(function() {
+   'use strict';
+
+    var fs = require('extfs');
+    
+    module.exports = {
+        // Check app for bower and npm dependencies
+        checkForDeps: function(directories) {
+            this.getToRoot();
+            var dependenciesFound = true;
+
+            directories.forEach(function(directory) {
+                var empty = fs.isEmptySync(directory);
+                    if (empty === true) {
+                        dependenciesFound = false;
+                    }
+            });
+
+            return dependenciesFound;
+        },
+        // Travel to project root folder
+        getToRoot: function() {
+            var filesInWorkingDir = fs.readdirSync('./');
+            var atProjectRoot = (filesInWorkingDir.indexOf("package.json") !== -1);
+
+            if (atProjectRoot) {
+                return;
+            }
+            else {
+                process.chdir("../");
+                this.getToRoot();
+            }
+        }
+    };
+
+}());
+ 


### PR DESCRIPTION
Adds a check for the bower_components and node_modules directories before trying to run/serve your application, and warns users if they're missing. #28
