### PR TITLE
Jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
   "latedef": true,
   "newcap": true,
   "noarg": true,
+  "node": true,
   "nonew": true,
   "quotmark": false,
   "undef": true,
@@ -20,7 +21,6 @@
   "globals": {
     "define": true,
     "module": true,
-    "require": true,
-    "process": true
+    "require": true
   }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,6 @@
   "trailing": false,
 
   "globals": {
-    "define": true,
-    "module": true
+    "define": true
   }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -20,7 +20,6 @@
 
   "globals": {
     "define": true,
-    "module": true,
-    "require": true
+    "module": true
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,36 +1,33 @@
-(function() {
-    'use strict';
+'use strict';
 
-    var fs = require('extfs');
+var fs = require('extfs');
 
-    module.exports = {
-        // Check app for bower and npm dependencies
-        checkForDeps: function(directories) {
-            this.getToRoot();
-            var dependenciesFound = true;
+module.exports = {
+    // Check app for bower and npm dependencies
+    checkForDeps: function(directories) {
+        this.getToRoot();
+        var dependenciesFound = true;
 
-            directories.forEach(function(directory) {
-                var empty = fs.isEmptySync(directory);
-                if (empty === true) {
-                    dependenciesFound = false;
-                }
-            });
-
-            return dependenciesFound;
-        },
-
-        // Travel to project root folder
-        getToRoot: function() {
-            var filesInWorkingDir = fs.readdirSync('./');
-            var atProjectRoot = filesInWorkingDir.indexOf('package.json') !== -1;
-
-            if (atProjectRoot) {
-                return;
-            } else {
-                process.chdir('../');
-                this.getToRoot();
+        directories.forEach(function(directory) {
+            var empty = fs.isEmptySync(directory);
+            if (empty === true) {
+                dependenciesFound = false;
             }
-        }
-    };
+        });
 
-}());
+        return dependenciesFound;
+    },
+
+    // Travel to project root folder
+    getToRoot: function() {
+        var filesInWorkingDir = fs.readdirSync('./');
+        var atProjectRoot = filesInWorkingDir.indexOf('package.json') !== -1;
+
+        if (atProjectRoot) {
+            return;
+        } else {
+            process.chdir('../');
+            this.getToRoot();
+        }
+    }
+};


### PR DESCRIPTION
Adds the `node` option to our jshintrc. This exposes variables like process/console/__dirname so we don't have to specify them all in our jshint globals. It also suppresses a complaint about using a function form of `use strict`.
