### PR TITLE
Show help info (resolves #44)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ module.exports = exports = function(grunt) {
     var sourceFiles = [
         'commands/*.js',
         'Gruntfile.js',
+        'help.js',
         'recroom.js',
         'src/*.js',
         'test/**/test.*.js',

--- a/command-model.js
+++ b/command-model.js
@@ -6,7 +6,7 @@ function Command(name) {
     this.binaryPath = __dirname + '/node_modules/.bin/';
     this.aliases = this.aliases || [];
     this.availableArguments = this.availableArguments || [];
-    this.options = this.options || [];
+    this.availableOptions = this.availableOptions || [];
 }
 
 Command.prototype.description = null;

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -5,11 +5,12 @@ var spawn = require('child_process').spawn;
 
 module.exports = {
     name: 'generate',
-    description: 'Creates a recroom project in a new folder.',
-    availableArguments: ['page', 'controller', 'model', 'route', 'view'],
+    description: 'Scaffolds the files needed to create a component of your app (model/view/controller/page)',
+    availableArguments: ['component', 'name'],
     aliases: ['g', 'scaffold'],
+    availableComponents: ['controller', 'model', 'page', 'view'],
     run: function(opts) {
-        if (['controller', 'model', 'page', 'view'].indexOf(
+        if (this.availableComponents.indexOf(
             opts.argv.remain[1]) === -1) {
             console.log(
                 chalk.red('"' + opts.argv.remain[1] +

--- a/commands/new.js
+++ b/commands/new.js
@@ -12,7 +12,12 @@ module.exports = {
     name: 'new',
     description: 'Creates a recroom project in a new folder.',
     availableArguments: ['app-name'],
-    availableOptions: ['cordova'],
+    availableOptions: [
+        {
+            name: 'cordova',
+            description: 'Creates a cordova structure in /dist-cordova'
+        }
+    ],
     aliases: ['create'],
     run: function(opts) {
         var projectName = opts.argv.remain[1] || DEFAULT_PROJECT_NAME;

--- a/help.js
+++ b/help.js
@@ -11,17 +11,12 @@ module.exports = {
         var configs = this.formatProps(command);
 
         var syntax = chalk.white('\nrecroom ' + command.name) +
-                                                configs.availableArguments +
-                                                configs.availableOptions;
-        var description = chalk.white('\n' + command.description);
+                     configs.availableArguments +
+                     configs.availableOptions;
+        var description = '\n' + chalk.white(command.description);
         var commandOptions = configs.optionDescriptions || '';
         
-        console.log(syntax,
-                    description, 
-                    configs.aliases,
-                    commandOptions,
-                    '\n'
-        );
+        console.log(syntax, description, configs.aliases, commandOptions, '\n');
     },
 
     // Formats command arguments, aliases and options for display
@@ -70,10 +65,9 @@ module.exports = {
     showHelpInfo: function(commandName) {
         if (commandName && recroomCommands['cmd_' + commandName]) {
             this.printCommandHelp(recroomCommands['cmd_' + commandName]);
-        }
-        else {
-            console.log('usage: recroom <command> [args]',
-                        chalk.yellow('\nAvailable Commands:')
+        } else {
+            console.log('usage: recroom <command> [args]\n' +
+                        chalk.yellow('Available Commands:')
             );
             for (var key in recroomCommands) {
                 var command = recroomCommands[key];

--- a/help.js
+++ b/help.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var chalk = require('chalk');
+var recroomCommands = require('./commands');
+var _ = require('underscore');
+
+module.exports = {
+
+    // Builds and logs help for a specific command
+    printCommandHelp: function(command) {
+        var configs = this.formatProps(command);
+
+        var syntax = chalk.white('\nrecroom ' + command.name) +
+                                                configs.availableArguments +
+                                                configs.availableOptions;
+        var description = chalk.white('\n' + command.description);
+        var commandOptions = configs.optionDescriptions || '';
+        
+        console.log(syntax,
+                    description, 
+                    configs.aliases,
+                    commandOptions,
+                    '\n'
+        );
+    },
+
+    // Formats command arguments, aliases and options for display
+    formatProps: function(command) {
+        var self = this;
+        var configs = _(command).pick('availableArguments', 'availableOptions', 'aliases');
+        var formattedConfigs = {};
+
+        _(configs).each(function(value, key) {
+            var formattedValue = '';
+            if (value.length > 0) {
+                switch (key) {
+                    case 'availableArguments':
+                        formattedValue = chalk.yellow(' <' + value.join('> <') + '> ');
+                        break;
+                    case 'availableOptions':
+                        formattedValue = chalk.blue('<options>');
+                        formattedConfigs.optionDescriptions = self.listCommandOptions(value);
+                        break;
+                    case 'aliases':
+                        formattedValue = chalk.gray('\naliases: ' + value.join(', '));
+                        break;
+                }
+            }
+
+            formattedConfigs[key] = formattedValue;
+        });  
+        
+        return formattedConfigs;
+    },
+
+    // Formats command options with descriptions for display
+    listCommandOptions: function(availableOptions) {
+        var formattedOptions = '\n';
+
+        _(availableOptions).each(function(option) {
+            formattedOptions += chalk.blue('\n  --' + 
+                                option.name + ' | ' + 
+                                option.description);
+        });
+
+        return formattedOptions;
+    },
+
+    // Logs help info for all commands or an explicitly specified command
+    showHelpInfo: function(commandName) {
+        if (commandName && recroomCommands['cmd_' + commandName]) {
+            this.printCommandHelp(recroomCommands['cmd_' + commandName]);
+        }
+        else {
+            console.log('usage: recroom <command> [args]',
+                        chalk.yellow('\nAvailable Commands:')
+            );
+            for (var key in recroomCommands) {
+                var command = recroomCommands[key];
+                this.printCommandHelp(command);
+            }
+        }
+    }
+
+
+};

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-cli": "~0.1.13",
     "generator-recroom": ">=0.1.1",
     "semver": "~4.0.3",
+    "underscore": "~1.7.0",
     "yo": ">=1.0.0"
   },
   "devDependencies": {

--- a/recroom.js
+++ b/recroom.js
@@ -7,6 +7,10 @@ var chalk = require('chalk');
 var nopt = require('nopt');
 var shell = require('shelljs');
 
+var banner = require('./banner');
+var recroomCommands = require('./commands');
+var help = require('./help');
+
 var opts = nopt({
     app: Boolean,
     banner: Boolean,
@@ -18,8 +22,11 @@ var opts = nopt({
     v: '--version'
 });
 
-var recroomCommands = require('./commands');
-var banner = require('./banner');
+// Display help info
+if (opts.help) {
+    help.showHelpInfo(opts.argv.remain[0]);
+    process.exit();
+}
 
 // Display version information.
 if (opts.version) {


### PR DESCRIPTION
Adds some basic info about available commands when running `recroom --help` as mentioned in #44 
