### PR TITLE
Warn users if bower component test frameworks are missing (resolves #30)

### DIFF
--- a/commands/test.js
+++ b/commands/test.js
@@ -1,13 +1,27 @@
 'use strict';
 
+var chalk = require('chalk');
+var shell = require('shelljs');
 var spawn = require('child_process').spawn;
+var util = require('../utils');
 
 module.exports = {
     name: 'test',
     description: 'Runs all unit tests in your application',
     run: function() {
-        spawn(this.binaryPath + 'grunt', ['test'], {
-            stdio: 'inherit'
-        });
+        var dependenciesExist = util.checkForDeps([
+            'test/bower_components'
+        ]);
+        if (dependenciesExist === true) {
+            spawn(this.binaryPath + 'grunt', ['test'], {
+                stdio: 'inherit'
+            });
+        } else {
+            console.log(
+                chalk.red('Warning: Test dependencies are missing.') +
+                chalk.yellow('\nTry running `bower install` from the test directory of your application.')
+            );
+            shell.exit(1);
+        }
     }
 };


### PR DESCRIPTION
This adds a warning if users are missing their test framework libraries in the /test dir, to resolve #30. Tests cannot run if the test/bower_components directory is empty. (Alternatively, we could try running bower install from the test directory for them, on app creation or as they try to run tests.)

There is also another PR here: https://github.com/mozilla/generator-recroom/pull/24 on the generator that changes the port for testing to 9001. This will prevent any conflicts if a user is already running their app on 9000.
